### PR TITLE
starts the work to allow to setup and manage specific slots, add unblock

### DIFF
--- a/agent/unblock.go
+++ b/agent/unblock.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Juliano Martinez <juliano@martinez.io>
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-piv/piv-go/v2/piv"
+	"golang.org/x/term"
+)
+
+// UnblockPIN uses the PUK to unblock a locked PIN
+func UnblockPIN(yk *piv.YubiKey) error {
+	// First, check if the PIN is actually blocked
+	count, err := yk.Retries()
+	if err != nil {
+		return fmt.Errorf("failed to get PIN retries: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("PIN is not blocked, no need to unblock")
+	}
+
+	// Get the current PUK from the user
+	fmt.Print("Enter the current PUK: ")
+	puk, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to read PUK: %w", err)
+	}
+	fmt.Println()
+
+	// Get the new PIN
+	fmt.Print("Enter new PIN: ")
+	newPIN, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to read new PIN: %w", err)
+	}
+	fmt.Println()
+
+	// Confirm the new PIN
+	fmt.Print("Confirm new PIN: ")
+	confirmPIN, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to read confirmation PIN: %w", err)
+	}
+	fmt.Println()
+
+	// Check if PINs match
+	if string(newPIN) != string(confirmPIN) {
+		return fmt.Errorf("new PIN and confirmation do not match")
+	}
+
+	// Unblock the PIN by setting again the pin using the PUK
+	if err = yk.Unblock(string(puk), string(newPIN)); err != nil {
+		return fmt.Errorf("failed to unblock PIN: %w", err)
+	}
+
+	fmt.Println("✅ PIN successfully unblocked and reset")
+	return nil
+}

--- a/cmd/unblock.go
+++ b/cmd/unblock.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Juliano Martinez <juliano@martinez.io>
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/ncode/yubikey-agent/agent"
+	"github.com/spf13/cobra"
+)
+
+// unblockCmd represents the unblock command
+var unblockCmd = &cobra.Command{
+	Use:   "unblock",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		yubikeys, err := agent.LoadYubiKeys()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		if len(yubikeys) == 1 {
+			err = agent.UnblockPIN(yubikeys[0].Device)
+			if err != nil {
+				log.Fatalln(err)
+			}
+		} else {
+			if serial == 0 {
+				log.Fatalln("you must specify --serial when having more than one yubikey connected")
+			}
+
+			for _, key := range yubikeys {
+				if uint32(serial) == key.Serial {
+					err = agent.UnblockPIN(key.Device)
+					if err != nil {
+						log.Fatalln(err)
+					}
+				}
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(unblockCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// unblockCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// unblockCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the YubiKey agent setup and adds new functionality for unblocking a PIN. The most important changes include the addition of new functions for resetting and setting up YubiKeys, improvements in key management, and the introduction of a new command for unblocking a PIN.

### New Functions and Commands:

* [`agent/setup.go`](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1R46-R76): Added `RunReset`, `RunResetSelected`, `RunSetup`, and `RunSetupSelected` functions to handle resetting and setting up YubiKeys. These functions streamline the process and ensure proper handling of multiple YubiKeys. [[1]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1R46-R76) [[2]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L152-R123) [[3]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1R159) [[4]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1R361-R379)
* [`agent/unblock.go`](diffhunk://#diff-37a3bde532260d806515ac31e734cf770e9bfaaa3a4443e2b77cce8c1d1b50d7R1-R64): Introduced the `UnblockPIN` function to unblock a locked PIN using the PUK. This function includes user prompts for entering the PUK and new PIN.
* [`cmd/unblock.go`](diffhunk://#diff-6cc2d9d7982246a955cdfaae3e676fe45c2789978617f1ab4b47207edd9fbc99R1-R66): Added a new `unblock` command to the CLI, which utilizes the `UnblockPIN` function to unblock a PIN. This command handles multiple YubiKeys and requires specifying a serial number if more than one YubiKey is connected.

### Key Management Improvements:

* [`agent/setup.go`](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L228-R274): Modified the `generateAndStoreSSHKey` function to improve error handling and ensure proper key generation and storage. This includes generating a new EC key, creating a self-signed certificate, and printing the SSH public key.
* [`agent/setup.go`](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L270-R306): Improved the management key setup process by generating a new random management key and updating the YubiKey from default credentials to the new key. This ensures better security and management of the YubiKey. [[1]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L270-R306) [[2]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L287-R324) [[3]](diffhunk://#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L315-R349)